### PR TITLE
Fix russion spellout rules

### DIFF
--- a/icu4c/source/data/rbnf/ru.txt
+++ b/icu4c/source/data/rbnf/ru.txt
@@ -90,7 +90,7 @@ ru{
             "0: =%spellout-cardinal-masculine=;",
             "%spellout-cardinal-masculine:",
             "-x: \u043C\u0438\u043D\u0443\u0441 >>;",
-            "x.x: [<%spellout-cardinal-feminine< $(cardinal,one{\u0446\u0435\u043B\u044B\u0439}other{\u0446\u0435\u043B\u044B\u0445})$ ]>%%fractions-feminine>;",
+            "x.x: [<%spellout-cardinal-feminine< $(cardinal,one{\u0446\u0435\u043B\u0430\u044F}other{\u0446\u0435\u043B\u044B\u0445})$ ]>%%fractions-feminine>;",
             "0: \u043D\u043E\u043B\u044C;",
             "1: \u043E\u0434\u0438\u043D;",
             "2: \u0434\u0432\u0430;",


### PR DESCRIPTION
Fix russian spelling for integer part of a fractional number, e.g. '21.1':
expected 'двадцать одна **целая** одна десятая'
actual      'двадцать одна **целый** одна десятая'

```
NumberFormat format = new RuleBasedNumberFormat(Locale.of("ru"), RuleBasedNumberFormat.SPELLOUT);
String str = format.format(21.1); // "двадцать одна целый одна десятая"
```